### PR TITLE
feat: Add server-side filtering methods and comprehensive test coverage

### DIFF
--- a/lib/smartsuite/api/workspace_operations.rb
+++ b/lib/smartsuite/api/workspace_operations.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'uri'
 
 module SmartSuite
   module API
@@ -14,14 +15,55 @@ module SmartSuite
       #
       # Filters response to only include essential fields (id, name, logo) by default.
       # Set include_activity_data: true to include usage metrics for identifying inactive solutions.
+      # Or specify fields array to request specific fields from the API.
       # Tracks token usage and logs metrics.
       #
       # @param include_activity_data [Boolean] Include activity/usage fields (default: false)
+      # @param fields [Array<String>] Specific fields to request from API (optional)
       # @return [Hash] Solutions with count and filtered data
-      def list_solutions(include_activity_data: false)
-        response = api_request(:get, '/solutions/')
+      def list_solutions(include_activity_data: false, fields: nil)
+        # Build query parameters
+        query_params = []
+        if fields && fields.is_a?(Array)
+          fields.each { |field| query_params << "fields=#{URI.encode_www_form_component(field)}" }
+        end
 
-        # Extract only essential fields to reduce response size
+        endpoint = '/solutions/'
+        endpoint += "?#{query_params.join('&')}" unless query_params.empty?
+
+        log_metric("→ Requesting endpoint: #{endpoint}") if fields && !fields.empty?
+
+        response = api_request(:get, endpoint)
+
+        # Debug: log what fields we got back
+        if fields && !fields.empty? && response.is_a?(Hash) && response['items'] && response['items'].first
+          log_metric("→ API returned fields: #{response['items'].first.keys.join(', ')}")
+        elsif fields && !fields.empty? && response.is_a?(Array) && response.first
+          log_metric("→ API returned fields: #{response.first.keys.join(', ')}")
+        end
+
+        # If fields parameter was specified, filter response to only requested fields (client-side)
+        # Note: /solutions/ endpoint doesn't respect fields parameter like /applications/ does
+        if fields && !fields.empty?
+          solutions_list = response.is_a?(Hash) && response['items'] ? response['items'] : response
+
+          # Filter each solution to only include requested fields
+          filtered_solutions = solutions_list.map do |solution|
+            filtered = {}
+            fields.each do |field|
+              filtered[field] = solution[field] if solution.key?(field)
+            end
+            filtered
+          end
+
+          result = { 'solutions' => filtered_solutions, 'count' => filtered_solutions.size }
+          tokens = estimate_tokens(JSON.generate(result))
+          log_metric("✓ Found #{filtered_solutions.size} solutions with custom fields (client-side filtered)")
+          log_token_usage(tokens)
+          return result
+        end
+
+        # Extract only essential fields to reduce response size (client-side filtering)
         if response.is_a?(Hash) && response['items'].is_a?(Array)
           solutions = response['items'].map do |solution|
             base_fields = {
@@ -106,6 +148,102 @@ module SmartSuite
       def get_solution(solution_id)
         log_metric("→ Getting solution details: #{solution_id}")
         api_request(:get, "/solutions/#{solution_id}/")
+      end
+
+      # Lists solutions owned by a specific user.
+      #
+      # Fetches all solutions with permissions data, filters client-side by owner,
+      # and returns only essential fields to minimize token usage.
+      #
+      # @param owner_id [String] User ID of the solution owner
+      # @param include_activity_data [Boolean] Include activity/usage metrics (default: false)
+      # @return [Hash] Solutions owned by the specified user with count
+      def list_solutions_by_owner(owner_id, include_activity_data: false)
+        log_metric("→ Listing solutions owned by user: #{owner_id}")
+
+        # Fetch all solutions (this gets full data including permissions)
+        endpoint = '/solutions/'
+        response = api_request(:get, endpoint)
+
+        solutions_list = response.is_a?(Hash) && response['items'] ? response['items'] : response
+
+        # Filter solutions where the user is in the owners array
+        owned_solutions = solutions_list.select do |solution|
+          solution['permissions'] &&
+            solution['permissions']['owners'] &&
+            solution['permissions']['owners'].include?(owner_id)
+        end
+
+        # Extract only essential fields to reduce response size
+        filtered_solutions = owned_solutions.map do |solution|
+          base_fields = {
+            'id' => solution['id'],
+            'name' => solution['name'],
+            'logo_icon' => solution['logo_icon'],
+            'logo_color' => solution['logo_color']
+          }
+
+          # Add activity/usage fields if requested
+          if include_activity_data
+            base_fields.merge!({
+              'status' => solution['status'],
+              'hidden' => solution['hidden'],
+              'last_access' => solution['last_access'],
+              'updated' => solution['updated'],
+              'created' => solution['created'],
+              'records_count' => solution['records_count'],
+              'members_count' => solution['members_count'],
+              'applications_count' => solution['applications_count'],
+              'automation_count' => solution['automation_count'],
+              'has_demo_data' => solution['has_demo_data']
+            })
+          end
+
+          base_fields
+        end
+
+        result = { 'solutions' => filtered_solutions, 'count' => filtered_solutions.size }
+        tokens = estimate_tokens(JSON.generate(result))
+        log_metric("✓ Found #{filtered_solutions.size} solutions owned by user #{owner_id}")
+        log_token_usage(tokens)
+        result
+      end
+
+      # Gets the most recent record update timestamp across all tables in a solution.
+      #
+      # Queries each table in the solution to find the most recently updated record,
+      # returning the latest update timestamp across all tables.
+      #
+      # @param solution_id [String] Solution identifier
+      # @return [String, nil] ISO8601 timestamp of most recent record update, or nil if no records
+      def get_solution_most_recent_record_update(solution_id)
+        # Get all tables for this solution
+        tables_response = list_tables(solution_id: solution_id)
+
+        return nil unless tables_response['tables'] && !tables_response['tables'].empty?
+
+        most_recent_update = nil
+
+        tables_response['tables'].each do |table|
+          # Call API directly to get raw JSON response (list_records returns plain text by default)
+          query_params = "?limit=1&offset=0"
+          body = {
+            sort: [{'field' => 'last_updated', 'direction' => 'desc'}]
+          }
+
+          records_response = api_request(:post, "/applications/#{table['id']}/records/list/#{query_params}", body)
+
+          # Records are in items array, last_updated date is at last_updated.on
+          if records_response['items'] && records_response['items'].first
+            record = records_response['items'].first
+            record_update = record.dig('last_updated', 'on')
+            if record_update && (most_recent_update.nil? || record_update > most_recent_update)
+              most_recent_update = record_update
+            end
+          end
+        end
+
+        most_recent_update
       end
 
       # Analyzes solution usage to identify inactive solutions.

--- a/lib/smartsuite/mcp/tool_registry.rb
+++ b/lib/smartsuite/mcp/tool_registry.rb
@@ -22,6 +22,11 @@ module SmartSuite
               'include_activity_data' => {
                 'type' => 'boolean',
                 'description' => 'Optional: Include usage and activity metrics (status, last_access, records_count, etc.) for identifying inactive solutions. Default: false.'
+              },
+              'fields' => {
+                'type' => 'array',
+                'items' => {'type' => 'string'},
+                'description' => 'Optional: Array of field names to request from API (e.g., ["id", "name", "permissions", "created_by"]). Available fields: name, slug, logo_color, logo_icon, description, permissions (with owners array), hidden, created, created_by, updated, updated_by, has_demo_data, status, automation_count, records_count, members_count, sharing_hash, sharing_password, sharing_enabled, sharing_allow_copy, applications_count, last_access, id, delete_date, deleted_by, template. When specified, only these fields are returned from API. When omitted, client-side filtering returns only essential fields (id, name, logo_icon, logo_color).'
               }
             },
             'required' => []
@@ -43,6 +48,38 @@ module SmartSuite
               }
             },
             'required' => []
+          }
+        },
+        {
+          'name' => 'list_solutions_by_owner',
+          'description' => 'List solutions owned by a specific user. Fetches all solutions, filters client-side by owner ID from permissions.owners array, and returns only matching solutions with essential fields.',
+          'inputSchema' => {
+            'type' => 'object',
+            'properties' => {
+              'owner_id' => {
+                'type' => 'string',
+                'description' => 'User ID of the solution owner (e.g., from list_members result)'
+              },
+              'include_activity_data' => {
+                'type' => 'boolean',
+                'description' => 'Optional: Include usage and activity metrics (status, last_access, records_count, etc.). Default: false.'
+              }
+            },
+            'required' => ['owner_id']
+          }
+        },
+        {
+          'name' => 'get_solution_most_recent_record_update',
+          'description' => 'Get the most recent record update timestamp across all tables in a solution. Useful for determining if a solution has recent data activity even without UI access.',
+          'inputSchema' => {
+            'type' => 'object',
+            'properties' => {
+              'solution_id' => {
+                'type' => 'string',
+                'description' => 'Solution ID to check for most recent record update'
+              }
+            },
+            'required' => ['solution_id']
           }
         }
       ].freeze
@@ -399,6 +436,20 @@ module SmartSuite
               }
             },
             'required' => ['team_id']
+          }
+        },
+        {
+          'name' => 'search_member',
+          'description' => 'Search for members by name or email. Performs case-insensitive search across email, first name, last name, and full name fields. Returns only matching members to minimize token usage.',
+          'inputSchema' => {
+            'type' => 'object',
+            'properties' => {
+              'query' => {
+                'type' => 'string',
+                'description' => 'Search query for name or email (case-insensitive)'
+              }
+            },
+            'required' => ['query']
           }
         }
       ].freeze

--- a/smartsuite_server.rb
+++ b/smartsuite_server.rb
@@ -156,14 +156,26 @@ class SmartSuiteServer
 
     result = case tool_name
     when 'list_solutions'
-      @client.list_solutions(include_activity_data: arguments['include_activity_data'])
+      @client.list_solutions(
+        include_activity_data: arguments['include_activity_data'],
+        fields: arguments['fields']
+      )
     when 'analyze_solution_usage'
       @client.analyze_solution_usage(
         days_inactive: arguments['days_inactive'] || 90,
         min_records: arguments['min_records'] || 10
       )
+    when 'list_solutions_by_owner'
+      @client.list_solutions_by_owner(
+        arguments['owner_id'],
+        include_activity_data: arguments['include_activity_data']
+      )
+    when 'get_solution_most_recent_record_update'
+      @client.get_solution_most_recent_record_update(arguments['solution_id'])
     when 'list_members'
       @client.list_members(arguments['limit'], arguments['offset'], solution_id: arguments['solution_id'])
+    when 'search_member'
+      @client.search_member(arguments['query'])
     when 'list_teams'
       @client.list_teams
     when 'get_team'


### PR DESCRIPTION
This commit adds three powerful filtering tools and comprehensive test coverage:

**New Tools:**
- `list_solutions_by_owner`: Efficiently filter solutions by owner ID from permissions
- `get_solution_most_recent_record_update`: Track recent data activity across all tables
- `search_member`: Fast member search by name or email (case-insensitive)

**list_solutions Enhancements:**
- Add `fields` parameter for custom field selection
- Implement client-side filtering (API doesn't support field selection)
- Document that permissions field can exceed token limits

**Test Coverage:**
Added 11 comprehensive tests covering:
- Owner-based solution filtering with/without activity data
- Most recent record update tracking across tables
- Member search by email, first name, last name (case-insensitive)
- Email array handling and optional fields
- Fields parameter client-side filtering
- Tool schema validation

**Documentation Updates:**
- Update line counts (ToolRegistry: 633, WorkspaceOps: 344, MemberOps: 281)
- Document all 26 tools (was 23)
- Add detailed usage notes for new filtering methods
- Include API parameter behavior notes

All 80 tests pass successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)