### PR TITLE
fix: Extract date values from nested hash in date filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Changed 5 instances in `cache/layer.rb`: `insert_record` (line 308), `cache_table_records` (line 250), `invalidate_table_cache` (line 520), `cache_valid?` (line 543), `invalidate_records_for_solution` (line 1116)
     - All cache INSERT, DELETE, UPDATE, and SELECT operations now logged to `~/.smartsuite_mcp_queries.log`
     - Makes cache operations visible for debugging and monitoring
+- **Date filter with nested hash values** - Fixed SQLite binding error when filtering by date fields with nested value objects
+  - Bug: When SmartSuite API sent date filters with nested format like `{"field": "due_date", "comparison": "is_after", "value": {"date_mode": "exact_date", "date_mode_value": "2025-11-18"}}`, FilterBuilder passed the entire hash to Cache::Query which tried to bind it as an SQL parameter, causing "no such bind parameter" SQLite error
+  - Fix: Added `extract_date_value` helper method to `FilterBuilder` to extract the actual date string from `value['date_mode_value']` when value is a nested hash
+  - Modified `convert_comparison` method to use `extract_date_value` for all date operators: `is_before`, `is_after`, `is_on_or_before`, `is_on_or_after`
+  - Maintains backward compatibility with simple date string format (e.g., "2025-11-18")
+  - Added 10 comprehensive regression tests in `test/test_filter_builder.rb` to prevent similar bugs:
+    - Tests for `extract_date_value` helper with simple string, nested hash, and nil values
+    - Tests for all date operators (`is_after`, `is_before`, `is_on_or_after`, `is_on_or_before`) with both nested hash and simple string formats
+    - Integration tests for `apply_to_query` with nested date filter and mixed date formats
 
 ## [1.9.0] - 2025-11-18
 

--- a/lib/smartsuite/filter_builder.rb
+++ b/lib/smartsuite/filter_builder.rb
@@ -137,16 +137,38 @@ module SmartSuite
         { has_none_of: value }
 
       # Date operators (map to numeric comparisons)
+      # Extract actual date value if value is a hash with date_mode_value
       when 'is_before'
-        { lt: value }
+        { lt: extract_date_value(value) }
       when 'is_after'
-        { gt: value }
+        { gt: extract_date_value(value) }
       when 'is_on_or_before'
-        { lte: value }
+        { lte: extract_date_value(value) }
       when 'is_on_or_after'
-        { gte: value }
+        { gte: extract_date_value(value) }
 
       # Default: equality
+      else
+        value
+      end
+    end
+
+    # Extract date value from SmartSuite date object format.
+    #
+    # SmartSuite date filters can come in two formats:
+    # 1. Simple string: "2025-01-01"
+    # 2. Date object: {"date_mode" => "exact_date", "date_mode_value" => "2025-01-01"}
+    #
+    # This method normalizes both formats to return the actual date string.
+    #
+    # @param value [String, Hash] Date value (simple string or nested hash)
+    # @return [String] Actual date string
+    # @example
+    #   extract_date_value("2025-01-01")                                     #=> "2025-01-01"
+    #   extract_date_value({"date_mode" => "exact_date", "date_mode_value" => "2025-01-01"}) #=> "2025-01-01"
+    def self.extract_date_value(value)
+      if value.is_a?(Hash) && value['date_mode_value']
+        value['date_mode_value']
       else
         value
       end


### PR DESCRIPTION
## Summary

Fixed SQLite binding error when filtering by date fields with nested value objects from SmartSuite API.

## Bug Description

When SmartSuite API sent date filters with nested format:
```json
{
  "field": "due_date",
  "comparison": "is_after",
  "value": {
    "date_mode": "exact_date",
    "date_mode_value": "2025-11-18"
  }
}
```

FilterBuilder passed the entire hash to Cache::Query which tried to bind it as an SQL parameter, causing "no such bind parameter" SQLite error.

## Solution

- Added `extract_date_value` helper method to FilterBuilder to extract actual date string from `value['date_mode_value']`
- Modified `convert_comparison` to use `extract_date_value` for date operators: `is_before`, `is_after`, `is_on_or_before`, `is_on_or_after`
- Maintains backward compatibility with simple date string format (e.g., "2025-11-18")

## Changes

- `lib/smartsuite/filter_builder.rb`: Added `extract_date_value` helper method and updated date operator handling
- `test/test_filter_builder.rb`: Added 10 comprehensive regression tests
- `CHANGELOG.md`: Documented the bug fix

## Testing

✅ All 513 tests pass with 1772 assertions  
✅ RuboCop: no offenses detected  
✅ YARD documentation: 99.14% coverage  
✅ Verified fix works with actual MCP server call using nested date filter

## Test Plan

- [x] Unit tests for `extract_date_value` with simple string, nested hash, and nil values
- [x] Tests for all date operators with both nested hash and simple string formats
- [x] Integration tests for `apply_to_query` with nested date filter
- [x] Manual verification with MCP server using exact failing parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)