### PR TITLE
fix: Check WinGet exit code and try multiple Ruby package IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Windows Ruby WinGet installation fix** - Fixed Ruby installation via WinGet
   - Now checks `$LASTEXITCODE` to verify WinGet installation actually succeeded
-  - Tries multiple package IDs in order: `RubyInstallerTeam.RubyWithDevKit.3.3`, `.3.2`, then generic
+  - Tries multiple package IDs in order: 3.4 (latest stable), 3.3, 3.2, then generic
   - Shows clear error message if no Ruby package can be found
 
 ## [2.0.0] - 2025-11-24

--- a/install.ps1
+++ b/install.ps1
@@ -48,26 +48,33 @@ function Install-Ruby {
         Print-Info "Installing Ruby using Windows Package Manager (WinGet)..."
         Print-Info "This may take a few minutes..."
 
-        # Try to install Ruby+Devkit (try specific version first, then generic)
+        # Try to install Ruby+Devkit (try latest version first, then older versions)
         $installed = $false
 
-        # Try Ruby 3.3 with DevKit first
-        Print-Info "Trying RubyInstallerTeam.RubyWithDevKit.3.3..."
-        winget install --id RubyInstallerTeam.RubyWithDevKit.3.3 --silent --accept-package-agreements --accept-source-agreements 2>$null
+        # Try Ruby 3.4 with DevKit first (latest stable)
+        Print-Info "Trying RubyInstallerTeam.RubyWithDevKit.3.4..."
+        winget install --id RubyInstallerTeam.RubyWithDevKit.3.4 --silent --accept-package-agreements --accept-source-agreements 2>$null
         if ($LASTEXITCODE -eq 0) {
             $installed = $true
         } else {
-            # Try Ruby 3.2 with DevKit
-            Print-Info "Trying RubyInstallerTeam.RubyWithDevKit.3.2..."
-            winget install --id RubyInstallerTeam.RubyWithDevKit.3.2 --silent --accept-package-agreements --accept-source-agreements 2>$null
+            # Try Ruby 3.3 with DevKit
+            Print-Info "Trying RubyInstallerTeam.RubyWithDevKit.3.3..."
+            winget install --id RubyInstallerTeam.RubyWithDevKit.3.3 --silent --accept-package-agreements --accept-source-agreements 2>$null
             if ($LASTEXITCODE -eq 0) {
                 $installed = $true
             } else {
-                # Try generic Ruby with DevKit
-                Print-Info "Trying RubyInstallerTeam.RubyWithDevKit..."
-                winget install --id RubyInstallerTeam.RubyWithDevKit --silent --accept-package-agreements --accept-source-agreements 2>$null
+                # Try Ruby 3.2 with DevKit
+                Print-Info "Trying RubyInstallerTeam.RubyWithDevKit.3.2..."
+                winget install --id RubyInstallerTeam.RubyWithDevKit.3.2 --silent --accept-package-agreements --accept-source-agreements 2>$null
                 if ($LASTEXITCODE -eq 0) {
                     $installed = $true
+                } else {
+                    # Try generic Ruby with DevKit
+                    Print-Info "Trying RubyInstallerTeam.RubyWithDevKit..."
+                    winget install --id RubyInstallerTeam.RubyWithDevKit --silent --accept-package-agreements --accept-source-agreements 2>$null
+                    if ($LASTEXITCODE -eq 0) {
+                        $installed = $true
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Fixes Ruby installation via WinGet that was failing silently

## Problem

The install script was printing `[OK] Ruby installed successfully` even when WinGet failed with `No package found matching input criteria`. This happened because:
1. We weren't checking `$LASTEXITCODE` after the winget command
2. The generic package ID `RubyInstallerTeam.RubyWithDevKit` may not exist on all WinGet sources

## Solution

- Check `$LASTEXITCODE` after each winget install attempt
- Try multiple package IDs in order of preference:
  1. `RubyInstallerTeam.RubyWithDevKit.3.3` (Ruby 3.3)
  2. `RubyInstallerTeam.RubyWithDevKit.3.2` (Ruby 3.2)
  3. `RubyInstallerTeam.RubyWithDevKit` (generic/latest)
- Show clear error message if no package can be found

## Test plan

- [ ] Run install script on Windows where Ruby is not installed
- [ ] Verify WinGet tries multiple package IDs
- [ ] Verify proper error message if no package found

🤖 Generated with [Claude Code](https://claude.com/claude-code)